### PR TITLE
feat: enhance double banner with responsive layout

### DIFF
--- a/admin/views/banner-types/double-banner/double-banner-editor.php
+++ b/admin/views/banner-types/double-banner/double-banner-editor.php
@@ -1,195 +1,19 @@
 <?php require YAB_PLUGIN_DIR . 'admin/views/components/banner-editor-header.php'; ?>
 
 <main class="grid grid-cols-12 gap-6 p-6 ltr">
-    <div class="col-span-4 overflow-y-auto ltr flex gap-3 flex-col [&>*:last-child]:mb-[40px]" style="max-height: calc(100vh - 120px);">
-        <div v-for="(b, key) in { left: banner.left, right: banner.right }" :key="key" class="bg-[#434343] p-5 rounded-lg shadow-xl">
-            
-            <h3 class="font-bold text-xl text-white capitalize tracking-wide mb-5">{{ key }} Banner Settings</h3>
-            
-            <div class="flex flex-col gap-5">
-                <div>
-                    <h4 class="section-title">Background</h4>
-                    <div class="flex gap-2 mb-2">
-                        <button @click="b.backgroundType = 'solid'" :class="{'active-tab': b.backgroundType === 'solid'}" class="flex-1 tab-button">Solid Color</button>
-                        <button @click="b.backgroundType = 'gradient'" :class="{'active-tab': b.backgroundType === 'gradient'}" class="flex-1 tab-button">Gradient</button>
-                    </div>
-                    <div v-if="b.backgroundType === 'solid'" class="space-y-2">
-                        <label class="setting-label-sm">Background Color</label>
-                        <div class="yab-color-input-wrapper">
-                            <input type="color" v-model="b.bgColor" class="yab-color-picker">
-                            <input type="text" v-model="b.bgColor" class="yab-hex-input" placeholder="#hexcode">
-                        </div>
-                    </div>
-                    <div v-else class="space-y-2">
-                         <div>
-                            <label class="setting-label-sm">Gradient Colors</label>
-                            <div class="grid grid-cols-2 gap-2">
-                                <div class="yab-color-input-wrapper">
-                                    <input type="color" v-model="b.gradientColor1" class="yab-color-picker">
-                                    <input type="text" v-model="b.gradientColor1" class="yab-hex-input" placeholder="#hexcode">
-                                </div>
-                                <div class="yab-color-input-wrapper">
-                                    <input type="color" v-model="b.gradientColor2" class="yab-color-picker">
-                                    <input type="text" v-model="b.gradientColor2" class="yab-hex-input" placeholder="#hexcode">
-                                </div>
-                            </div>
-                        </div>
-                        <div>
-                            <label class="setting-label-sm">Gradient Angle</label>
-                            <div class="flex items-center gap-2">
-                                <input type="number" v-model.number="b.gradientAngle" class="yab-form-input w-24" placeholder="e.g., 90">
-                                <span class="text-sm text-gray-400">deg</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <hr class="section-divider">
-                <div>
-                    <h4 class="section-title">Image</h4>
-                    <div class="flex gap-2 items-center">
-                        <button @click="openMediaUploader(key)" class="flex-1 bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700 text-sm">
-                            {{ b.imageUrl ? 'Change Image' : 'Select Image' }}
-                        </button>
-                        <button v-if="b.imageUrl" @click="removeImage(key)" class="bg-red-600 text-white px-3 py-1.5 rounded-md hover:bg-red-700 text-sm">
-                            Remove
-                        </button>
-                    </div>
-                    <div v-if="b.imageUrl" class="mt-3 space-y-3">
-                        <div v-if="!b.enableCustomImageSize" class="flex items-center gap-2">
-                            <label class="setting-label-sm w-20">Image Fit:</label>
-                            <select v-model="b.imageFit" class="yab-form-input flex-1">
-                                <option value="cover">Cover</option>
-                                <option value="contain">Contain</option>
-                                <option value="fill">Fill</option>
-                                <option value="none">None (Natural Size)</option>
-                            </select>
-                        </div>
-                        <div class="flex items-center justify-between bg-[#292929] p-2 rounded-md">
-                            <label class="setting-label-sm">Enable Custom Image Size</label>
-                            <label class="relative inline-flex items-center cursor-pointer">
-                                <input type="checkbox" v-model="b.enableCustomImageSize" class="sr-only peer">
-                                <div class="w-11 h-6 bg-gray-600 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-500"></div>
-                            </label>
-                        </div>
-                         <div v-if="b.enableCustomImageSize" class="grid grid-cols-2 gap-2">
-                             <div>
-                                <label class="setting-label-sm">Width (px)</label>
-                                <input type="number" v-model.number="b.imageWidth" class="yab-form-input" placeholder="Width">
-                             </div>
-                             <div>
-                                <label class="setting-label-sm">Height (px)</label>
-                                <input type="number" v-model.number="b.imageHeight" class="yab-form-input" placeholder="Height">
-                            </div>
-                        </div>
-                         <div class="grid grid-cols-2 gap-2 mt-2">
-                            <div>
-                               <label class="setting-label-sm">Right (px)</label>
-                               <input type="number" v-model.number="b.imagePosRight" class="yab-form-input" placeholder="Right">
-                            </div>
-                            <div>
-                                <label class="setting-label-sm">Bottom (px)</label>
-                                <input type="number" v-model.number="b.imagePosBottom" class="yab-form-input" placeholder="Bottom">
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <hr class="section-divider">
-                <div>
-                        <h4 class="section-title">Content Alignment</h4>
-                        <div class="flex rounded-lg bg-[#292929] overflow-hidden ">
-                        <button @click="b.alignment = 'left'" :class="b.alignment === 'left' ? 'bg-[#00baa4] text-white' : 'text-gray-300'" class="px-3 py-1 text-sm transition-colors duration-300 flex-1">Left</button>
-                        <button @click="b.alignment = 'center'" :class="b.alignment === 'center' ? 'bg-[#00baa4] text-white' : 'text-gray-300'" class="px-3 py-1 text-sm transition-colors duration-300 flex-1">Center</button>
-                        <button @click="b.alignment = 'right'" :class="b.alignment === 'right' ? 'bg-[#00baa4] text-white' : 'text-gray-300'" class="px-3 py-1 text-sm transition-colors duration-300 flex-1">Right</button>
-                    </div>
-                </div>
-                <hr class="section-divider">
-                <div class="space-y-2">
-                    <h4 class="section-title">Title</h4>
-                     <label class="setting-label-sm">Title Text</label>
-                    <input type="text" v-model="b.titleText" class="yab-form-input mb-2" placeholder="Title Text">
-                    <div class="grid grid-cols-2 gap-2">
-                         <div>
-                            <label class="setting-label-sm">Color</label>
-                            <div class="yab-color-input-wrapper">
-                                <input type="color" v-model="b.titleColor" class="yab-color-picker">
-                                <input type="text" v-model="b.titleColor" class="yab-hex-input" placeholder="#hexcode">
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-2 gap-2">
-                            <div>
-                                <label class="setting-label-sm">Size (px)</label>
-                                <input type="number" v-model.number="b.titleSize" class="yab-form-input" placeholder="Size">
-                            </div>
-                            <div>
-                                <label class="setting-label-sm">Weight</label>
-                                <select v-model="b.titleWeight" class="yab-form-input">
-                                    <option value="400">Normal</option><option value="500">Medium</option><option value="600">Semi-Bold</option><option value="700">Bold</option><option value="800">Extra Bold</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <hr class="section-divider">
-                <div class="space-y-2">
-                    <h4 class="section-title">Description</h4>
-                    <label class="setting-label-sm">Description Text</label>
-                    <textarea v-model="b.descText" rows="3" class="yab-form-input mb-2" placeholder="Description Text"></textarea>
-                    <div class="grid grid-cols-2 gap-2">
-                        <div>
-                            <label class="setting-label-sm">Color</label>
-                            <div class="yab-color-input-wrapper">
-                                <input type="color" v-model="b.descColor" class="yab-color-picker">
-                                <input type="text" v-model="b.descColor" class="yab-hex-input" placeholder="#hexcode">
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-2 gap-2">
-                            <div>
-                                <label class="setting-label-sm">Size (px)</label>
-                                <input type="number" v-model.number="b.descSize" class="yab-form-input" placeholder="Size">
-                            </div>
-                            <div>
-                                <label class="setting-label-sm">Weight</label>
-                                <select v-model="b.descWeight" class="yab-form-input">
-                                    <option value="400">Normal</option><option value="500">Medium</option><option value="600">Semi-Bold</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <hr class="section-divider">
-                <div class="space-y-2">
-                    <h4 class="section-title">Button</h4>
-                    <label class="setting-label-sm">Button Text</label>
-                    <input type="text" v-model="b.buttonText" class="yab-form-input mb-2" placeholder="Button Text">
-                    <label class="setting-label-sm">Button Link (URL)</label>
-                    <input type="text" v-model="b.buttonLink" class="yab-form-input mb-2" placeholder="https://example.com">
-                    <div class="grid grid-cols-2 gap-2 mb-2">
-                        <div>
-                            <label class="setting-label-sm">Background Color</label>
-                            <div class="yab-color-input-wrapper">
-                                <input type="color" v-model="b.buttonBgColor" class="yab-color-picker">
-                                <input type="text" v-model="b.buttonBgColor" class="yab-hex-input" placeholder="BG #hex">
-                            </div>
-                        </div>
-                        <div>
-                            <label class="setting-label-sm">Text Color</label>
-                            <div class="yab-color-input-wrapper">
-                                <input type="color" v-model="b.buttonTextColor" class="yab-color-picker">
-                                <input type="text" v-model="b.buttonTextColor" class="yab-hex-input" placeholder="Text #hex">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="grid grid-cols-2 gap-2">
-                        <div>
-                            <label class="setting-label-sm">Hover BG Color</label>
-                            <div class="yab-color-input-wrapper">
-                                <input type="color" v-model="b.buttonBgHoverColor" class="yab-color-picker">
-                                <input type="text" v-model="b.buttonBgHoverColor" class="yab-hex-input" placeholder="Hover #hex">
-                            </div>
-                        </div>
-                         <div>
-                            <label class="setting-label-sm">Font Size (px)</label>
-                            <input type="number" v-model.number="b.buttonFontSize" class="yab-form-input" placeholder="Font Size">
+    <div class="col-span-4 overflow-y-auto flex flex-col gap-6 [&>*:last-child]:mb-[40px]" style="max-height: calc(100vh - 120px);">
+        <div class="bg-[#434343] p-5 rounded-lg shadow-xl">
+            <div class="flex mb-4 bg-[#292929] rounded-lg p-1">
+                <button @click="currentView = 'desktop'" :class="{'active-tab': currentView === 'desktop'}" class="flex-1 tab-button rounded-md">Desktop</button>
+                <button @click="currentView = 'mobile'" :class="{'active-tab': currentView === 'mobile'}" class="flex-1 tab-button rounded-md">Mobile</button>
+            </div>
+            <div v-if="banner.left && banner.right && banner.left_mobile && banner.right_mobile" :key="currentView">
+                <h3 class="font-bold text-xl text-white tracking-wide mb-4 capitalize">{{ currentView }} Settings</h3>
+                <div class="flex flex-col gap-5">
+                    <div v-for="side in ['left','right']" :key="side" class="bg-[#434343] p-5 rounded-lg shadow-xl">
+                        <h3 class="font-bold text-xl text-white capitalize tracking-wide mb-5">{{ side }} Banner Settings</h3>
+                        <div class="flex flex-col gap-5">
+                            <?php require 'double-banner-settings.php'; ?>
                         </div>
                     </div>
                 </div>
@@ -200,31 +24,48 @@
     <div class="col-span-8 sticky top-[120px] space-y-4">
         <div class="bg-[#434343] p-4 rounded-lg">
             <h3 class="preview-title">Live Preview</h3>
-            <div class="flex flex-row gap-2 justify-center">
-                <div v-for="(b, key) in { left: banner.left, right: banner.right }" :key="`preview-${key}`" 
-                    class="rounded-[11.35px] relative overflow-hidden flex flex-shrink-0" 
-                    :style="{ background: bannerStyles(b), width: '432px', height: '177px' }">
-                    
-                    <img v-if="b.imageUrl" :src="b.imageUrl" :style="imageStyleObject(b)" />
-
-                    <div class="w-full h-full py-[37px] px-[31px] flex flex-col z-10 relative" :style="{ alignItems: contentAlignment(b.alignment), textAlign: b.alignment }">
-                        <h4 class="font-bold " :style="{ color: b.titleColor, fontSize: b.titleSize + 'px', fontWeight: b.titleWeight, margin: 0 }">{{ b.titleText }}</h4>
-                        <p class="mt-2 leading-tight mb-[25px]" :style="{ color: b.descColor, fontSize: b.descSize + 'px', fontWeight: b.descWeight, whiteSpace: 'pre-wrap' ,}">{{ b.descText }}</p>
-                        <a v-if="b.buttonText" :href="b.buttonLink" target="_blank" 
-                            class="py-2 px-4 rounded mt-auto" 
-                            :style="{ backgroundColor: b.buttonBgColor, color: b.buttonTextColor, fontSize: b.buttonFontSize + 'px', alignSelf: buttonAlignment(b.alignment) }">
-                            {{ b.buttonText }}
-                        </a>
+            <transition name="fade" mode="out-in">
+                <div v-if="currentView === 'desktop'" class="flex flex-row gap-[20px] justify-center">
+                    <div v-for="side in ['left','right']" :key="`preview-desktop-${side}`" :style="getPartContainerStyles(side, 'desktop')" class="relative overflow-hidden flex flex-shrink-0">
+                        <template v-if="banner[side].layerOrder === 'overlay-top'">
+                            <img v-if="banner[side].imageUrl" :src="banner[side].imageUrl" :style="{...imageStyleObject(banner[side]), zIndex: 1}" />
+                            <div class="absolute inset-0" :style="{background: bannerStyles(banner[side]), zIndex: 2}"></div>
+                        </template>
+                        <template v-else>
+                            <div class="absolute inset-0" :style="{background: bannerStyles(banner[side]), zIndex: 1}"></div>
+                            <img v-if="banner[side].imageUrl" :src="banner[side].imageUrl" :style="{...imageStyleObject(banner[side]), zIndex: 2}" />
+                        </template>
+                        <div class="w-full h-full flex flex-col z-10 relative" :style="getPartDynamicStyles(side, 'desktop').contentStyles">
+                            <h4 :style="getPartDynamicStyles(side, 'desktop').titleStyles">{{ banner[side].titleText }}</h4>
+                            <p :style="getPartDynamicStyles(side, 'desktop').descriptionStyles">{{ banner[side].descText }}</p>
+                            <a v-if="banner[side].buttonText" :href="banner[side].buttonLink" target="_blank" :style="getPartDynamicStyles(side, 'desktop').buttonStyles">{{ banner[side].buttonText }}</a>
+                        </div>
                     </div>
                 </div>
-            </div>
+                <div v-else-if="currentView === 'mobile'" class="flex flex-col gap-[20px] items-center">
+                    <div v-for="side in ['left','right']" :key="`preview-mobile-${side}`" :style="getPartContainerStyles(side, 'mobile')" class="relative overflow-hidden w-full">
+                        <template v-if="banner[side + '_mobile'].layerOrder === 'overlay-top'">
+                            <img v-if="banner[side + '_mobile'].imageUrl" :src="banner[side + '_mobile'].imageUrl" :style="{...imageStyleObject(banner[side + '_mobile']), zIndex: 1}" />
+                            <div class="absolute inset-0" :style="{background: bannerStyles(banner[side + '_mobile']), zIndex: 2}"></div>
+                        </template>
+                        <template v-else>
+                            <div class="absolute inset-0" :style="{background: bannerStyles(banner[side + '_mobile']), zIndex: 1}"></div>
+                            <img v-if="banner[side + '_mobile'].imageUrl" :src="banner[side + '_mobile'].imageUrl" :style="{...imageStyleObject(banner[side + '_mobile']), zIndex: 2}" />
+                        </template>
+                        <div class="w-full h-full flex flex-col z-10 relative" :style="getPartDynamicStyles(side, 'mobile').contentStyles">
+                            <h4 :style="getPartDynamicStyles(side, 'mobile').titleStyles">{{ banner[side + '_mobile'].titleText }}</h4>
+                            <p :style="getPartDynamicStyles(side, 'mobile').descriptionStyles">{{ banner[side + '_mobile'].descText }}</p>
+                            <a v-if="banner[side + '_mobile'].buttonText" :href="banner[side + '_mobile'].buttonLink" target="_blank" :style="getPartDynamicStyles(side, 'mobile').buttonStyles">{{ banner[side + '_mobile'].buttonText }}</a>
+                        </div>
+                    </div>
+                </div>
+            </transition>
         </div>
-        
-        <transition name="yab-modal-fade">
+
+        <transition name="fade">
             <div v-if="banner.displayMethod === 'Fixed'">
                 <?php require YAB_PLUGIN_DIR . 'admin/views/components/display-conditions.php'; ?>
             </div>
         </transition>
-
     </div>
 </main>

--- a/admin/views/banner-types/double-banner/double-banner-settings.php
+++ b/admin/views/banner-types/double-banner/double-banner-settings.php
@@ -1,0 +1,325 @@
+<div :set="settings = currentView === 'desktop' ? banner[side] : banner[side + '_mobile']">
+    <div>
+        <h4 class="section-title">Layout</h4>
+        <div class="flex items-center justify-between bg-[#292929] p-2 rounded-md mb-2">
+            <label class="setting-label-sm">Enable Custom Dimensions</label>
+            <label class="relative inline-flex items-center cursor-pointer" title="Toggle custom banner dimensions">
+                <input type="checkbox" v-model="settings.enableCustomDimensions" class="sr-only peer">
+                <div class="w-11 h-6 bg-gray-600 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-500"></div>
+            </label>
+        </div>
+        <div v-if="settings.enableCustomDimensions" class="grid grid-cols-2 gap-2">
+            <div>
+                <label class="setting-label-sm">Width</label>
+                <div class="flex items-center gap-1">
+                    <input type="number" v-model.number="settings.width" class="yab-form-input" placeholder="Width">
+                    <select v-model="settings.widthUnit" class="yab-form-input w-20"><option>px</option><option>%</option></select>
+                </div>
+            </div>
+            <div>
+                <label class="setting-label-sm">Min Height</label>
+                <div class="flex items-center gap-1">
+                    <input type="number" v-model.number="settings.minHeight" class="yab-form-input" placeholder="Min Height">
+                    <select v-model="settings.minHeightUnit" class="yab-form-input w-20"><option>px</option><option>%</option></select>
+                </div>
+            </div>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div>
+        <h4 class="section-title">Border</h4>
+        <div class="flex items-center justify-between bg-[#292929] p-2 rounded-md mb-2">
+            <label class="setting-label-sm">Enable Border</label>
+            <label class="relative inline-flex items-center cursor-pointer" title="Toggle banner border">
+                <input type="checkbox" v-model="settings.enableBorder" class="sr-only peer">
+                <div class="w-11 h-6 bg-gray-600 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-500"></div>
+            </label>
+        </div>
+        <div v-if="settings.enableBorder" class="grid grid-cols-3 gap-2">
+            <div v-if="currentView === 'desktop'">
+                <label class="setting-label-sm">Color</label>
+                <div class="yab-color-input-wrapper">
+                    <input type="color" v-model="settings.borderColor" class="yab-color-picker">
+                    <input type="text" v-model="settings.borderColor" class="yab-hex-input" placeholder="Color">
+                </div>
+            </div>
+            <div :class="{'col-span-3': currentView === 'mobile', 'col-span-2': currentView === 'desktop'}">
+                <div class="grid grid-cols-2 gap-2">
+                    <div>
+                        <label class="setting-label-sm">Width (px)</label>
+                        <input type="number" v-model.number="settings.borderWidth" class="yab-form-input" placeholder="e.g., 1">
+                    </div>
+                    <div>
+                        <label class="setting-label-sm">Radius (px)</label>
+                        <input type="number" v-model.number="settings.borderRadius" class="yab-form-input" placeholder="e.g., 16">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div>
+        <h4 class="section-title">Content Padding (px)</h4>
+        <div class="grid grid-cols-2 gap-2">
+            <div>
+                <label class="setting-label-sm">Top</label>
+                <input type="number" v-model.number="settings.paddingTop" class="yab-form-input" placeholder="Top">
+            </div>
+            <div>
+                <label class="setting-label-sm">Right</label>
+                <input type="number" v-model.number="settings.paddingRight" class="yab-form-input" placeholder="Right">
+            </div>
+            <div>
+                <label class="setting-label-sm">Bottom</label>
+                <input type="number" v-model.number="settings.paddingBottom" class="yab-form-input" placeholder="Bottom">
+            </div>
+            <div>
+                <label class="setting-label-sm">Left</label>
+                <input type="number" v-model.number="settings.paddingLeft" class="yab-form-input" placeholder="Left">
+            </div>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div>
+        <h4 class="section-title">Background Overlay</h4>
+        <p class="text-xs text-gray-400 mb-2">Configure the desktop background first; you can then override it for the mobile view.</p>
+        <div class="flex gap-2 mb-2 bg-[#292929] rounded-lg border-none">
+            <button @click="settings.backgroundType = 'solid'" :class="{'active-tab': settings.backgroundType === 'solid'}" class="flex-1 tab-button rounded-l-lg border-none">Solid Color</button>
+            <button @click="settings.backgroundType = 'gradient'" :class="{'active-tab': settings.backgroundType === 'gradient'}" class="flex-1 tab-button rounded-r-lg border-none">Gradient</button>
+        </div>
+        <div v-if="settings.backgroundType === 'solid'" class="space-y-2">
+            <label class="setting-label-sm">Color (supports transparency)</label>
+            <div class="yab-color-input-wrapper">
+                <input type="color" v-model="settings.bgColor" class="yab-color-picker">
+                <input type="text" v-model="settings.bgColor" class="yab-hex-input" placeholder="e.g., rgba(0,0,0,0.5)">
+            </div>
+        </div>
+        <div v-else class="space-y-4">
+            <div>
+                <label class="setting-label-sm">Gradient Angle: {{ settings.gradientAngle }}deg</label>
+                <div class="flex items-center gap-2">
+                    <input type="range" v-model.number="settings.gradientAngle" min="0" max="360" class="w-full">
+                    <input type="number" v-model.number="settings.gradientAngle" class="yab-form-input w-20 text-center">
+                </div>
+            </div>
+            <div>
+                <label class="setting-label-sm">Gradient Colors</label>
+                <div v-for="(stop, index) in settings.gradientStops" :key="index" class="bg-[#292929] p-3 rounded-lg mb-2 space-y-2">
+                    <div class="flex items-center justify-between">
+                        <span class="text-xs font-bold text-gray-300">Color Stop #{{ index + 1 }}</span>
+                        <button v-if="settings.gradientStops.length > 1" @click="removeGradientStop(settings, index)" class="text-red-500 hover:text-red-400 text-xs">Remove</button>
+                    </div>
+                    <div class="grid grid-cols-2 gap-2">
+                        <div class="yab-color-input-wrapper">
+                            <input type="color" v-model="stop.color" class="yab-color-picker">
+                            <input type="text" v-model="stop.color" class="yab-hex-input" placeholder="e.g., transparent">
+                        </div>
+                        <button @click="stop.color = 'transparent'" class="bg-gray-600 text-white text-xs rounded-md hover:bg-gray-500">Set Transparent</button>
+                    </div>
+                    <div>
+                        <label class="setting-label-sm">Position: {{ stop.stop }}%</label>
+                        <input type="range" v-model.number="stop.stop" min="0" max="100" class="w-full">
+                    </div>
+                </div>
+                <button @click="addGradientStop(settings)" class="w-full bg-blue-600 text-white text-sm py-2 rounded-md hover:bg-blue-700 mt-2">Add Color Stop</button>
+            </div>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div>
+        <h4 class="section-title">Layer Order</h4>
+        <div class="flex rounded-lg bg-[#292929] overflow-hidden">
+            <button @click="settings.layerOrder = 'overlay-top'" :class="settings.layerOrder === 'overlay-top' ? 'active-tab' : ''" class="flex-1 tab-button">Color Over Image</button>
+            <button @click="settings.layerOrder = 'image-top'" :class="settings.layerOrder === 'image-top' ? 'active-tab' : ''" class="flex-1 tab-button">Image Over Color</button>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div>
+        <h4 class="section-title">Image</h4>
+        <div v-if="currentView === 'desktop'" class="flex gap-2 items-center">
+            <button @click="openMediaUploader(currentView === 'desktop' ? side : side + '_mobile')" class="flex-1 bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700 text-sm">
+                {{ settings.imageUrl ? 'Change Image' : 'Select Image' }}
+            </button>
+            <button v-if="settings.imageUrl" @click="removeImage(currentView === 'desktop' ? side : side + '_mobile')" class="bg-red-600 text-white px-3 py-1.5 rounded-md hover:bg-red-700 text-sm">
+                Remove
+            </button>
+        </div>
+        <div v-if="settings.imageUrl" class="mt-3 space-y-3">
+            <div class="flex items-center justify-between bg-[#292929] p-2 rounded-md">
+                <label class="setting-label-sm">Enable Custom Image Size</label>
+                <label class="relative inline-flex items-center cursor-pointer">
+                    <input type="checkbox" v-model="settings.enableCustomImageSize" class="sr-only peer">
+                    <div class="w-11 h-6 bg-gray-600 rounded-full peer peer-focus:ring-2 peer-focus:ring-blue-500 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-500"></div>
+                </label>
+            </div>
+            <div v-if="settings.enableCustomImageSize" class="grid grid-cols-2 gap-2">
+                <div>
+                    <label class="setting-label-sm">Width</label>
+                    <div class="flex items-center gap-1">
+                        <input type="number" v-model.number="settings.imageWidth" class="yab-form-input" placeholder="Auto">
+                        <select v-model="settings.imageWidthUnit" class="yab-form-input w-20"><option>px</option><option>%</option></select>
+                    </div>
+                </div>
+                <div>
+                    <label class="setting-label-sm">Height</label>
+                    <div class="flex items-center gap-1">
+                        <input type="number" v-model.number="settings.imageHeight" class="yab-form-input" placeholder="100%">
+                        <select v-model="settings.imageHeightUnit" class="yab-form-input w-20"><option>px</option><option>%</option></select>
+                    </div>
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-2 mt-2">
+                <div>
+                    <label class="setting-label-sm">Right (px)</label>
+                    <input type="number" v-model.number="settings.imagePosRight" class="yab-form-input" placeholder="Right">
+                </div>
+                <div>
+                    <label class="setting-label-sm">Bottom (px)</label>
+                    <input type="number" v-model.number="settings.imagePosBottom" class="yab-form-input" placeholder="Bottom">
+                </div>
+            </div>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div v-if="currentView === 'desktop'">
+        <h4 class="section-title">Content Alignment</h4>
+        <div class="flex rounded-lg bg-[#292929] overflow-hidden">
+            <button @click="settings.alignment = 'left'" :class="settings.alignment === 'left' ? 'active-tab' : ''" class="flex-1 tab-button rounded-l-lg">Left</button>
+            <button @click="settings.alignment = 'center'" :class="settings.alignment === 'center' ? 'active-tab' : ''" class="flex-1 tab-button">Center</button>
+            <button @click="settings.alignment = 'right'" :class="settings.alignment === 'right' ? 'active-tab' : ''" class="flex-1 tab-button rounded-r-lg">Right</button>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div class="space-y-2">
+        <h4 class="section-title">Title</h4>
+        <div v-if="currentView === 'desktop'">
+            <label class="setting-label-sm">Title Text</label>
+            <input type="text" v-model="settings.titleText" class="yab-form-input mb-2" placeholder="Title Text">
+        </div>
+        <div class="grid grid-cols-2 gap-2">
+            <div v-if="currentView === 'desktop'">
+                <label class="setting-label-sm">Color</label>
+                <div class="yab-color-input-wrapper">
+                    <input type="color" v-model="settings.titleColor" class="yab-color-picker">
+                    <input type="text" v-model="settings.titleColor" class="yab-hex-input" placeholder="#hexcode">
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-2" :class="{'col-span-2': currentView === 'mobile'}">
+                <div>
+                    <label class="setting-label-sm">Size (px)</label>
+                    <input type="number" v-model.number="settings.titleSize" class="yab-form-input" placeholder="Size">
+                </div>
+                <div>
+                    <label class="setting-label-sm">Weight</label>
+                    <select v-model="settings.titleWeight" class="yab-form-input">
+                        <option value="400">Normal</option>
+                        <option value="500">Medium</option>
+                        <option value="600">Semi-Bold</option>
+                        <option value="700">Bold</option>
+                        <option value="800">Extra Bold</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div class="space-y-2">
+        <h4 class="section-title">Description</h4>
+        <label class="setting-label-sm" v-if="currentView === 'desktop'">Description Text</label>
+        <textarea v-if="currentView === 'desktop'" v-model="settings.descText" rows="3" class="yab-form-input mb-2" placeholder="Description Text"></textarea>
+        <div class="grid grid-cols-2 gap-2">
+            <div v-if="currentView === 'desktop'">
+                <label class="setting-label-sm">Color</label>
+                <div class="yab-color-input-wrapper">
+                    <input type="color" v-model="settings.descColor" class="yab-color-picker">
+                    <input type="text" v-model="settings.descColor" class="yab-hex-input" placeholder="#hexcode">
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-2" :class="{'col-span-2': currentView === 'mobile'}">
+                <div>
+                    <label class="setting-label-sm">Size (px)</label>
+                    <input type="number" v-model.number="settings.descSize" class="yab-form-input" placeholder="Size">
+                </div>
+                <div>
+                    <label class="setting-label-sm">Weight</label>
+                    <select v-model="settings.descWeight" class="yab-form-input">
+                        <option value="400">Normal</option>
+                        <option value="500">Medium</option>
+                        <option value="600">Semi-Bold</option>
+                    </select>
+                </div>
+            </div>
+            <div class="col-span-2">
+                <label class="setting-label-sm">Width</label>
+                <div class="flex items-center gap-1">
+                    <input type="number" v-model.number="settings.descWidth" class="yab-form-input" placeholder="Width">
+                    <select v-model="settings.descWidthUnit" class="yab-form-input w-20"><option>%</option><option>px</option></select>
+                </div>
+            </div>
+        </div>
+    </div>
+    <hr class="section-divider">
+    <div class="space-y-2">
+        <h4 class="section-title">Button</h4>
+        <label class="setting-label-sm">Button Text</label>
+        <input type="text" v-model="settings.buttonText" class="yab-form-input mb-2" placeholder="Button Text">
+        <label class="setting-label-sm">Button Link (URL)</label>
+        <input type="text" v-model="settings.buttonLink" class="yab-form-input mb-2" placeholder="https://example.com">
+        <div v-if="currentView === 'desktop'" class="grid grid-cols-2 gap-2 mb-2">
+            <div>
+                <label class="setting-label-sm">Background Color</label>
+                <div class="yab-color-input-wrapper">
+                    <input type="color" v-model="settings.buttonBgColor" class="yab-color-picker">
+                    <input type="text" v-model="settings.buttonBgColor" class="yab-hex-input" placeholder="BG #hex">
+                </div>
+            </div>
+            <div>
+                <label class="setting-label-sm">Text Color</label>
+                <div class="yab-color-input-wrapper">
+                    <input type="color" v-model="settings.buttonTextColor" class="yab-color-picker">
+                    <input type="text" v-model="settings.buttonTextColor" class="yab-hex-input" placeholder="Text #hex">
+                </div>
+            </div>
+        </div>
+        <div class="grid grid-cols-2 gap-2">
+            <div v-if="currentView === 'desktop'">
+                <label class="setting-label-sm">Hover BG Color</label>
+                <div class="yab-color-input-wrapper">
+                    <input type="color" v-model="settings.buttonBgHoverColor" class="yab-color-picker">
+                    <input type="text" v-model="settings.buttonBgHoverColor" class="yab-hex-input" placeholder="Hover #hex">
+                </div>
+            </div>
+            <div :class="{'col-span-2': currentView === 'mobile'}">
+                <label class="setting-label-sm">Font Size (px)</label>
+                <input type="number" v-model.number="settings.buttonFontSize" class="yab-form-input" placeholder="Font Size">
+            </div>
+        </div>
+        <div class="grid grid-cols-2 gap-2 mt-2">
+            <div>
+                <label class="setting-label-sm">Width</label>
+                <div class="flex items-center gap-1">
+                    <input type="number" v-model.number="settings.buttonWidth" class="yab-form-input" placeholder="Width">
+                    <select v-model="settings.buttonWidthUnit" class="yab-form-input w-20"><option>px</option><option>%</option></select>
+                </div>
+            </div>
+            <div>
+                <label class="setting-label-sm">Height</label>
+                <div class="flex items-center gap-1">
+                    <input type="number" v-model.number="settings.buttonHeight" class="yab-form-input" placeholder="Height">
+                    <select v-model="settings.buttonHeightUnit" class="yab-form-input w-20"><option>px</option><option>%</option></select>
+                </div>
+            </div>
+            <div>
+                <label class="setting-label-sm">Min-Width</label>
+                <div class="flex items-center gap-1">
+                    <input type="number" v-model.number="settings.buttonMinWidth" class="yab-form-input" placeholder="Min-Width">
+                    <select v-model="settings.buttonMinWidthUnit" class="yab-form-input w-20"><option>px</option><option>%</option></select>
+                </div>
+            </div>
+            <div>
+                <label class="setting-label-sm">Border Radius (px)</label>
+                <input type="number" v-model.number="settings.buttonBorderRadius" class="yab-form-input" placeholder="e.g., 4">
+            </div>
+        </div>
+    </div>
+</div>

--- a/assets/js/admin/app-logic/main.js
+++ b/assets/js/admin/app-logic/main.js
@@ -52,6 +52,15 @@ export function initializeApp(yabData) {
                     mobile.buttonHeightUnit = desktop.buttonHeightUnit;
                     mobile.buttonBorderRadius = desktop.buttonBorderRadius;
 
+                    ['left', 'right'].forEach(side => {
+                        const d = banner[side];
+                        const m = banner[`${side}_mobile`];
+                        Object.assign(m, JSON.parse(JSON.stringify(d)));
+                        m.width = 100;
+                        m.widthUnit = '%';
+                        m.minHeight = 110;
+                    });
+
                     banner.isMobileConfigured = true; // Mark as configured
                 }
             });
@@ -81,6 +90,38 @@ export function initializeApp(yabData) {
                 banner.single_mobile.buttonBgColor = newDesktopSettings.buttonBgColor;
                 banner.single_mobile.buttonBgHoverColor = newDesktopSettings.buttonBgHoverColor;
                 banner.single_mobile.buttonTextColor = newDesktopSettings.buttonTextColor;
+            }, { deep: true });
+
+            watch(() => ({
+                borderColor: banner.left.borderColor,
+                backgroundType: banner.left.backgroundType,
+                bgColor: banner.left.bgColor,
+                imageUrl: banner.left.imageUrl,
+                alignment: banner.left.alignment,
+                titleColor: banner.left.titleColor,
+                descText: banner.left.descText,
+                descColor: banner.left.descColor,
+                buttonBgColor: banner.left.buttonBgColor,
+                buttonBgHoverColor: banner.left.buttonBgHoverColor,
+                buttonTextColor: banner.left.buttonTextColor,
+            }), (newDesktopSettings) => {
+                Object.assign(banner.left_mobile, newDesktopSettings);
+            }, { deep: true });
+
+            watch(() => ({
+                borderColor: banner.right.borderColor,
+                backgroundType: banner.right.backgroundType,
+                bgColor: banner.right.bgColor,
+                imageUrl: banner.right.imageUrl,
+                alignment: banner.right.alignment,
+                titleColor: banner.right.titleColor,
+                descText: banner.right.descText,
+                descColor: banner.right.descColor,
+                buttonBgColor: banner.right.buttonBgColor,
+                buttonBgHoverColor: banner.right.buttonBgHoverColor,
+                buttonTextColor: banner.right.buttonTextColor,
+            }), (newDesktopSettings) => {
+                Object.assign(banner.right_mobile, newDesktopSettings);
             }, { deep: true });
 
 
@@ -123,22 +164,20 @@ export function initializeApp(yabData) {
                 }
             };
             
-            const getBannerContainerStyles = (view) => {
-                const settings = view === 'desktop' ? banner.single : banner.single_mobile;
+            const buildBannerContainerStyles = (settings) => {
                 if (!settings) return {};
                 return {
-                    width: settings.enableCustomDimensions ? `${settings.width}${settings.widthUnit}` : '100%',
+                    width: `${settings.width}${settings.widthUnit}`,
                     height: 'auto',
-                    minHeight: settings.enableCustomDimensions ? `${settings.minHeight}${settings.minHeightUnit}` : (view === 'desktop' ? '183px' : '110px'),
+                    minHeight: `${settings.minHeight}${settings.minHeightUnit}`,
                     border: settings.enableBorder ? `${settings.borderWidth}px solid ${settings.borderColor}` : 'none',
                     borderRadius: `${settings.borderRadius}px`
                 };
             };
-            
-            const getDynamicStyles = (view) => {
-                const settings = view === 'desktop' ? banner.single : banner.single_mobile;
+
+            const buildDynamicStyles = (settings) => {
                 if (!settings) return {};
-    
+
                 return {
                     contentStyles: {
                         alignItems: contentAlignment(settings.alignment),
@@ -157,11 +196,11 @@ export function initializeApp(yabData) {
                         fontSize: `${settings.descSize}px`,
                         fontWeight: settings.descWeight,
                         whiteSpace: 'pre-wrap',
-                        marginTop: `${settings.marginTopDescription || 10}px`,
-                        marginBottom: '10px',
+                        marginTop: `${settings.marginTopDescription || 12}px`,
+                        marginBottom: '25px',
                         lineHeight: settings.descLineHeight || 1.1,
-                        width: `${settings.descWidth}${settings.descWidthUnit}`, // *** ADDED: Description width ***
-                        wordWrap: 'break-word' // *** ADDED: Word wrap behavior ***
+                        width: `${settings.descWidth}${settings.descWidthUnit}`,
+                        wordWrap: 'break-word'
                     },
                     buttonStyles: {
                         backgroundColor: settings.buttonBgColor,
@@ -183,11 +222,16 @@ export function initializeApp(yabData) {
                     }
                 };
             };
-    
+
+            const getBannerContainerStyles = (view) => buildBannerContainerStyles(view === 'desktop' ? banner.single : banner.single_mobile);
+            const getDynamicStyles = (view) => buildDynamicStyles(view === 'desktop' ? banner.single : banner.single_mobile);
             const getContentStyles = (view) => getDynamicStyles(view).contentStyles;
             const getTitleStyles = (view) => getDynamicStyles(view).titleStyles;
             const getDescriptionStyles = (view) => getDynamicStyles(view).descriptionStyles;
             const getButtonStyles = (view) => getDynamicStyles(view).buttonStyles;
+
+            const getPartContainerStyles = (side, view) => buildBannerContainerStyles(view === 'desktop' ? banner[side] : banner[side + '_mobile']);
+            const getPartDynamicStyles = (side, view) => buildDynamicStyles(view === 'desktop' ? banner[side] : banner[side + '_mobile']);
 
             const selectElementType = (type) => { 
                 resetBannerState();
@@ -354,7 +398,9 @@ export function initializeApp(yabData) {
                 getButtonStyles,
                 addGradientStop,
                 removeGradientStop,
-                getBannerContainerStyles
+                getBannerContainerStyles,
+                getPartContainerStyles,
+                getPartDynamicStyles
             };
         },
         components: { 

--- a/assets/js/admin/composables/banner-state/bannerState.js
+++ b/assets/js/admin/composables/banner-state/bannerState.js
@@ -11,25 +11,39 @@ import {
 } from './defaults.js';
 
 export function useBannerState() {
-    const createDefaultBanner = () => ({
-        id: null, name: '', displayMethod: 'Fixed', isActive: true, type: null,
-        isMobileConfigured: false, // Flag to track if mobile has been configured once
-        displayOn: { posts: [], pages: [], categories: [] },
-        left: createDefaultPart(), right: createDefaultPart(), 
-        single: createDefaultPart(),
-        single_mobile: createDefaultMobilePart(),
-        simple: createDefaultSimplePart(),
-        sticky_simple: createDefaultSimplePart(),
-        promotion: createDefaultPromotionPart(),
-        content_html: createDefaultHtmlPart(),
-        content_html_sidebar: createDefaultHtmlSidebarPart(),
-        api: { 
-            apiType: null, 
-            selectedHotel: null, 
-            selectedTour: null,
-            design: createDefaultApiDesign(),
-        },
-    });
+    const createDefaultBanner = () => {
+        const left = createDefaultPart();
+        left.width = 50; left.widthUnit = '%'; left.minHeight = 185; left.paddingTop = 35; left.paddingBottom = 35; left.paddingRight = 31; left.paddingLeft = 31; left.buttonMinWidth = 143; left.marginTopDescription = 12;
+
+        const right = createDefaultPart();
+        right.width = 50; right.widthUnit = '%'; right.minHeight = 185; right.paddingTop = 35; right.paddingBottom = 35; right.paddingRight = 31; right.paddingLeft = 31; right.buttonMinWidth = 143; right.marginTopDescription = 12;
+
+        const left_mobile = createDefaultMobilePart();
+        left_mobile.paddingTop = 35; left_mobile.paddingBottom = 35; left_mobile.paddingRight = 31; left_mobile.paddingLeft = 31; left_mobile.buttonMinWidth = 143; left_mobile.marginTopDescription = 12;
+
+        const right_mobile = createDefaultMobilePart();
+        right_mobile.paddingTop = 35; right_mobile.paddingBottom = 35; right_mobile.paddingRight = 31; right_mobile.paddingLeft = 31; right_mobile.buttonMinWidth = 143; right_mobile.marginTopDescription = 12;
+
+        return {
+            id: null, name: '', displayMethod: 'Fixed', isActive: true, type: null,
+            isMobileConfigured: false, // Flag to track if mobile has been configured once
+            displayOn: { posts: [], pages: [], categories: [] },
+            left, right, left_mobile, right_mobile,
+            single: createDefaultPart(),
+            single_mobile: createDefaultMobilePart(),
+            simple: createDefaultSimplePart(),
+            sticky_simple: createDefaultSimplePart(),
+            promotion: createDefaultPromotionPart(),
+            content_html: createDefaultHtmlPart(),
+            content_html_sidebar: createDefaultHtmlSidebarPart(),
+            api: {
+                apiType: null,
+                selectedHotel: null,
+                selectedTour: null,
+                design: createDefaultApiDesign(),
+            },
+        };
+    };
 
     const banner = reactive(createDefaultBanner());
 
@@ -47,6 +61,12 @@ export function useBannerState() {
     const mergeWithExisting = (existingData) => {
         if (!existingData.single_mobile) {
             existingData.single_mobile = createDefaultMobilePart();
+        }
+        if (!existingData.left_mobile) {
+            existingData.left_mobile = createDefaultMobilePart();
+        }
+        if (!existingData.right_mobile) {
+            existingData.right_mobile = createDefaultMobilePart();
         }
 
         // If loading an existing banner, mark mobile as "configured" to prevent auto-copying

--- a/assets/js/admin/composables/banner-state/defaults.js
+++ b/assets/js/admin/composables/banner-state/defaults.js
@@ -19,6 +19,7 @@ export const createDefaultPart = () => ({
     descLineHeight: 1.1,
     descWidth: 100, // *** ADDED: Default description width ***
     descWidthUnit: '%', // *** ADDED: Default description width unit ***
+    layerOrder: 'overlay-top',
     buttonText: 'Learn More',
     buttonLink: '#',
     buttonBgColor: '#124C88',

--- a/public/Renderers/class-double-banner-renderer.php
+++ b/public/Renderers/class-double-banner-renderer.php
@@ -5,46 +5,154 @@ if (!class_exists('Yab_Double_Banner_Renderer')) {
     require_once __DIR__ . '/class-abstract-banner-renderer.php';
 
     class Yab_Double_Banner_Renderer extends Yab_Abstract_Banner_Renderer {
-        
         public function render(): string {
             if (empty($this->data['left']) || empty($this->data['right'])) {
                 return '';
             }
 
-            $banners = ['left' => $this->data['left'], 'right' => $this->data['right']];
+            $desktop = ['left' => $this->data['left'], 'right' => $this->data['right']];
+            $mobile = [
+                'left' => $this->data['left_mobile'] ?? $this->data['left'],
+                'right' => $this->data['right_mobile'] ?? $this->data['right'],
+            ];
             $banner_id = $this->banner_id;
 
             ob_start();
             ?>
             <style>
-                <?php foreach ($banners as $key => $b): ?>
-                    <?php if(!empty($b['buttonText']) && !empty($b['buttonBgHoverColor'])): ?>
-                    .yab-banner-<?php echo $banner_id; ?>-<?php echo $key; ?> .yab-button:hover {
-                        background-color: <?php echo esc_attr($b['buttonBgHoverColor']); ?> !important;
-                    }
-                    <?php endif; ?>
+                .yab-banner-wrapper-<?php echo $banner_id; ?> .yab-banner-mobile { display: none; }
+                .yab-banner-wrapper-<?php echo $banner_id; ?> .yab-banner-desktop { display: flex; }
+                @media (max-width: 768px) {
+                    .yab-banner-wrapper-<?php echo $banner_id; ?> .yab-banner-desktop { display: none; }
+                    .yab-banner-wrapper-<?php echo $banner_id; ?> .yab-banner-mobile { display: flex; }
+                }
+                <?php foreach (['desktop' => $desktop, 'mobile' => $mobile] as $view => $banners): ?>
+                    <?php foreach ($banners as $key => $b): if (!empty($b['buttonText']) && !empty($b['buttonBgHoverColor'])): ?>
+                        .yab-banner-wrapper-<?php echo $banner_id; ?> .yab-banner-<?php echo $view; ?> .yab-banner-<?php echo $key; ?> .yab-button:hover { background-color: <?php echo esc_attr($b['buttonBgHoverColor']); ?> !important; }
+                    <?php endif; endforeach; ?>
                 <?php endforeach; ?>
             </style>
-            <div class="yab-wrapper" style="display: flex; flex-direction: row; gap: 1rem; width: 100%; justify-content: center;line-height:1.2!important">
-                <?php foreach ($banners as $key => $b): ?>
-                <div class="yab-banner-item yab-banner-<?php echo $banner_id; ?>-<?php echo $key; ?>" style="width: 432px; height: 177px; border-radius: 0.5rem; position: relative; overflow: hidden;display: flex; flex-shrink: 0; <?php echo $this->get_background_style($b); ?>">
-                    
-                    <?php if (!empty($b['imageUrl'])): ?>
-                        <img src="<?php echo esc_url($b['imageUrl']); ?>" alt="" style="<?php echo $this->get_image_style($b); ?>">
-                    <?php endif; ?>
-
-                    <div style="width: 100%; height:100%; padding: 1.5rem; display: flex; flex-direction: column; z-index: 10; position: relative; <?php echo $this->get_alignment_style($b); ?>">
-                        <h4 style="font-weight: <?php echo esc_attr($b['titleWeight'] ?? '700'); ?>; color: <?php echo esc_attr($b['titleColor'] ?? '#ffffff'); ?>; font-size: <?php echo intval($b['titleSize'] ?? 15); ?>px; margin: 0;"><?php echo esc_html($b['titleText'] ?? ''); ?></h4>
-                        <p style="margin-top:0.5rem;margin-bottom:1.5rem;font-weight:<?php echo esc_attr($b['descWeight'] ?? '400'); ?>;color:<?php echo esc_attr($b['descColor'] ?? '#dddddd'); ?>;font-size:<?php echo intval($b['descSize'] ?? 10); ?>px;white-space:pre-wrap;"><?php echo wp_kses_post($b['descText'] ?? ''); ?></p>
-                        <?php if(!empty($b['buttonText'])): ?>
-                        <a href="<?php echo esc_url($b['buttonLink'] ?? '#'); ?>" target="_blank" class="yab-button" style="margin-top: auto; padding: 0.5rem 1rem; border-radius: 0.25rem; text-decoration: none; background-color: <?php echo esc_attr($b['buttonBgColor'] ?? '#00baa4'); ?>; color: <?php echo esc_attr($b['buttonTextColor'] ?? '#ffffff'); ?>; font-size: <?php echo intval($b['buttonFontSize'] ?? 10); ?>px; align-self: var(--align-self); transition: background-color 0.3s;"><?php echo esc_html($b['buttonText']); ?></a>
-                        <?php endif; ?>
-                    </div>
-                </div>
-                <?php endforeach; ?>
+            <div class="yab-wrapper yab-banner-wrapper-<?php echo $banner_id; ?>" style="width:100%; line-height:1.2!important; direction:ltr;">
+                <?php echo $this->render_view($desktop, 'desktop'); ?>
+                <?php echo $this->render_view($mobile, 'mobile'); ?>
             </div>
             <?php
             return ob_get_clean();
+        }
+
+        private function render_view(array $banners, string $view) {
+            $wrapper_style = $view === 'desktop' ? 'flex-direction: row;' : 'flex-direction: column;';
+            ob_start(); ?>
+            <div class="yab-banner-<?php echo $view; ?>" style="display:flex; <?php echo $wrapper_style; ?> gap:20px; width:100%; justify-content:center;">
+                <?php foreach ($banners as $key => $b): ?>
+                    <div class="yab-banner-item yab-banner-<?php echo $key; ?>" style="<?php echo $this->get_inline_style_attr($this->build_container_styles($b)); ?>">
+                        <?php echo $this->render_layers($b); ?>
+                        <?php $alignment = $this->get_alignment_style($b); ?>
+                        <div class="yab-banner-content" style="<?php echo $this->get_inline_style_attr($this->build_content_styles($b)); ?> text-align: <?php echo $alignment['text_align']; ?>; align-items: <?php echo $alignment['align_items']; ?>;">
+                            <h4 style="font-weight: <?php echo esc_attr($b['titleWeight'] ?? '700'); ?>; color: <?php echo esc_attr($b['titleColor'] ?? '#ffffff'); ?>; font-size: <?php echo intval($b['titleSize'] ?? 20); ?>px; margin:0;">
+                                <?php echo esc_html($b['titleText'] ?? ''); ?>
+                            </h4>
+                            <p style="<?php echo $this->get_inline_style_attr($this->build_desc_styles($b)); ?>">
+                                <?php echo wp_kses_post(trim($b['descText'] ?? '')); ?>
+                            </p>
+                            <?php if (!empty($b['buttonText'])): ?>
+                                <a href="<?php echo esc_url($b['buttonLink'] ?? '#'); ?>" target="_blank" class="yab-button" style="<?php echo $this->get_inline_style_attr($this->build_button_styles($b, $alignment)); ?>">
+                                    <?php echo esc_html($b['buttonText']); ?>
+                                </a>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+            <?php return ob_get_clean();
+        }
+
+        private function render_layers(array $b): string {
+            $layer = $b['layerOrder'] ?? 'overlay-top';
+            ob_start();
+            if ($layer === 'overlay-top') {
+                if (!empty($b['imageUrl'])) {
+                    echo '<img src="' . esc_url($b['imageUrl']) . '" alt="" style="' . $this->get_image_style($b) . ' z-index:1;">';
+                }
+                echo '<div class="yab-banner-overlay" style="position:absolute;top:0;left:0;right:0;bottom:0;z-index:2;' . $this->get_background_style($b) . '"></div>';
+            } else {
+                echo '<div class="yab-banner-overlay" style="position:absolute;top:0;left:0;right:0;bottom:0;z-index:1;' . $this->get_background_style($b) . '"></div>';
+                if (!empty($b['imageUrl'])) {
+                    echo '<img src="' . esc_url($b['imageUrl']) . '" alt="" style="' . $this->get_image_style($b) . ' z-index:2;">';
+                }
+            }
+            return ob_get_clean();
+        }
+
+        private function build_container_styles(array $b): array {
+            $styles = [
+                'width' => esc_attr(($b['width'] ?? 50) . ($b['widthUnit'] ?? '%')),
+                'height' => 'auto',
+                'min-height' => esc_attr(($b['minHeight'] ?? 185) . ($b['minHeightUnit'] ?? 'px')),
+                'border-radius' => esc_attr($b['borderRadius'] ?? 16) . 'px',
+                'position' => 'relative',
+                'overflow' => 'hidden',
+                'flex-shrink' => '0',
+            ];
+            if (!empty($b['enableBorder'])) {
+                $styles['border'] = esc_attr($b['borderWidth'] ?? 1) . 'px solid ' . esc_attr($b['borderColor'] ?? '#E0E0E0');
+            }
+            return $styles;
+        }
+
+        private function build_content_styles(array $b): array {
+            return [
+                'width' => '100%',
+                'padding' => sprintf('%spx %spx %spx %spx', esc_attr($b['paddingTop'] ?? 35), esc_attr($b['paddingRight'] ?? 31), esc_attr($b['paddingBottom'] ?? 35), esc_attr($b['paddingLeft'] ?? 31)),
+                'display' => 'flex',
+                'flex-direction' => 'column',
+                'z-index' => '10',
+                'position' => 'relative',
+                'flex-grow' => '1',
+            ];
+        }
+
+        private function build_desc_styles(array $b): array {
+            return [
+                'font-weight' => esc_attr($b['descWeight'] ?? '500'),
+                'color' => esc_attr($b['descColor'] ?? '#ffffff'),
+                'font-size' => esc_attr($b['descSize'] ?? 12) . 'px',
+                'margin-top' => esc_attr($b['marginTopDescription'] ?? 12) . 'px',
+                'margin-bottom' => '25px',
+                'line-height' => esc_attr($b['descLineHeight'] ?? 1.1),
+                'width' => esc_attr($b['descWidth'] ?? 100) . esc_attr($b['descWidthUnit'] ?? '%'),
+                'word-wrap' => 'break-word',
+            ];
+        }
+
+        private function build_button_styles(array $b, array $alignment): array {
+            return [
+                'text-decoration' => 'none',
+                'display' => 'inline-flex',
+                'align-items' => 'center',
+                'justify-content' => 'center',
+                'transition' => 'background-color 0.3s',
+                'padding' => sprintf('%spx %spx', esc_attr($b['buttonPaddingY'] ?? 9), esc_attr($b['buttonPaddingX'] ?? 23)),
+                'background-color' => esc_attr($b['buttonBgColor'] ?? '#124C88'),
+                'color' => esc_attr($b['buttonTextColor'] ?? '#ffffff'),
+                'font-size' => esc_attr($b['buttonFontSize'] ?? 14) . 'px',
+                'width' => !empty($b['buttonWidth']) ? esc_attr($b['buttonWidth'] . ($b['buttonWidthUnit'] ?? 'px')) : 'auto',
+                'height' => !empty($b['buttonHeight']) ? esc_attr($b['buttonHeight'] . ($b['buttonHeightUnit'] ?? 'px')) : 'auto',
+                'min-width' => esc_attr($b['buttonMinWidth'] ?? 143) . 'px',
+                'border-radius' => esc_attr($b['buttonBorderRadius'] ?? 5) . 'px',
+                'margin-top' => 'auto',
+                'font-weight' => esc_attr($b['buttonFontWeight'] ?? '600'),
+                'align-self' => $alignment['align_self'],
+                'line-height' => '1.15',
+            ];
+        }
+
+        private function get_inline_style_attr(array $styles): string {
+            $style_str = '';
+            foreach ($styles as $prop => $value) {
+                $style_str .= $prop . ': ' . $value . '; ';
+            }
+            return trim($style_str);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add comprehensive settings and responsive preview for double banner
- support mobile-specific banner data and layer order
- implement renderer with dynamic styling and 20px gap

## Testing
- `php -l admin/views/banner-types/double-banner/double-banner-editor.php`
- `php -l admin/views/banner-types/double-banner/double-banner-settings.php`
- `php -l public/Renderers/class-double-banner-renderer.php`
- `node --check assets/js/admin/composables/banner-state/defaults.js`
- `node --check assets/js/admin/composables/banner-state/bannerState.js`
- `node --check assets/js/admin/app-logic/main.js`


------
https://chatgpt.com/codex/tasks/task_b_68bb724252cc8325899ec3a4da640948